### PR TITLE
Feature/139284015/cancel order

### DIFF
--- a/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
@@ -29,6 +29,8 @@ Template.cartCompleted.helpers({
   orderStatus: function () {
     if (this.workflow.status === "new") {
       return i18next.t("cartCompleted.submitted");
+    } else if (this.workflow.status === "canceled") {
+      return "Canceled";
     }
     return this.workflow.status;
   },

--- a/imports/plugins/core/orders/client/templates/list/ordersList.html
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.html
@@ -19,11 +19,7 @@
           </strong>
         </div>
         <div class="col-xs-6 col-sm-10">
-          {{#if orderStatus}}
-              <span data-i18n="order.completed">Completed</span>
-          {{else}}
-              <span data-i18n="order.processing">Processing</span>
-          {{/if}}
+          {{ orderStatus }}
         </div>
       </div>
 

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -8,9 +8,12 @@ import { Orders, Shops } from "/lib/collections";
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
-    if (this.workflow.status === "coreOrderCompleted") {
-      return true;
+    if (this.workflow.status === "coreOrderWorkflow/completed") {
+      return "Completed";
+    } else if (this.workflow.status === "canceled") {
+      return "Canceled";
     }
+    return "Processing";
   },
   orders(data) {
     if (data.hash.data) {

--- a/imports/plugins/core/orders/client/templates/list/summary.html
+++ b/imports/plugins/core/orders/client/templates/list/summary.html
@@ -62,6 +62,11 @@
         {{/each}}
       </div>
     </div>
-
+    {{#if orderStatus}}
+    <div></div>
+    {{else}}
+    <div class="panel panel-default">
+    <button name="cancel" class="btn btn-sm btn-danger" type="submit" data-event-action="cancelOrder" data-i18n="order.cancelOrder">Cancel Order</button></div>
+    {{/if}}
   </div>
 </template>

--- a/imports/plugins/core/orders/client/templates/list/summary.js
+++ b/imports/plugins/core/orders/client/templates/list/summary.js
@@ -1,6 +1,16 @@
 import { Template } from "meteor/templating";
 import { NumericInput } from "/imports/plugins/core/ui/client/components";
 
+Template.ordersListSummary.onCreated(function () {
+  this.state = new ReactiveDict();
+
+  this.autorun(() => {
+    const currentData = Template.currentData();
+    const order = currentData.order;
+    this.state.set("order", order);
+  });
+});
+
 /**
  * ordersListSummary helpers
  *
@@ -20,5 +30,48 @@ Template.ordersListSummary.helpers({
       format: currencyFormat,
       isEditing: false
     };
+  },
+
+  displayCancelButton() {
+    return !(this.order.workflow.status === "canceled"
+     || this.order.workflow.status === "coreOrderWorkflow/canceled");
+  },
+
+  orderStatus() {
+    return this.order.workflow.status === "canceled";
+  }
+});
+
+/**
+ * ordersListSummary events
+ */
+Template.ordersListSummary.events({
+  /**
+  * Submit form
+  * @param  {Event} event - Event object
+ * @param  {Template} instance - Blaze Template
+* @return {void}
+*/
+  "click button[name=cancel]"(event, instance) {
+    event.stopPropagation();
+
+    const state = instance.state;
+    const order = state.get("order");
+
+    swal({
+      title: "Are you sure?",
+      text: "You want to cancel the order placed!",
+      type: "warning",
+      showCancelButton: true,
+      confirmButtonClass: ".btn-danger",
+      confirmButtonText: "Yes!"
+    })
+    .then(() => {
+      Meteor.call("orders/cancelOrder", order, (error) => {
+        if (error) {
+          swal("Order cancellation unsuccesful.", "success");
+        }
+      });
+    });
   }
 });

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -13,6 +13,9 @@ const orderFilters = [{
 }, {
   name: "completed",
   label: "Completed"
+}, {
+  name: "canceled",
+  label: "Canceled"
 }];
 
 const OrderHelper =  {
@@ -163,6 +166,9 @@ Template.ordersListItem.helpers({
 
   orderIsNew(order) {
     return order.workflow.status === "new";
+  },
+  isCanceled(order) {
+    return (order.workflow.status === "canceled");
   }
 });
 
@@ -301,6 +307,9 @@ Template.orderStatusDetail.helpers({
       return this.shipping[0].tracking;
     }
     return i18next.t("orderShipping.noTracking");
+  },
+  orderStatus: function () {
+    return this.workflow.status;
   },
 
   shipmentStatus() {

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -210,6 +210,30 @@ Meteor.methods({
       }
     });
   },
+
+  /**
+   * orders/cancelOrder
+   *
+   * @summary Cancel an Order
+   * @param {Object} order - order object
+   * @param {Object} newComment - new comment object
+   * @return {Object} return updated result
+   */
+  "orders/cancelOrder"(order) {
+    check(order, Object);
+
+    // Update Order
+    return Orders.update(order._id, {
+      $set: {
+        "workflow.status": "canceled"
+      },
+      $addToSet: {
+        "workflow.workflow": "coreOrderWorkflow/canceled"
+      }
+    });
+  },
+
+  /**
   /**
    * orders/shipmentShipped
    *


### PR DESCRIPTION
 #### What does this PR do? 
Adds a cancel order option to both Admin and Guest user

 #### Description of Task to be completed?
Add "cancel order" option.

 #### How should this be manually tested?

 #### What are the relevant pivotal tracker stories?
#139284015

 #### Screenshots (if appropriate)
This is the page to cancel an order after an order has been completed

<img width="1416" alt="screen shot 2017-02-27 at 2 10 48 pm" src="https://cloud.githubusercontent.com/assets/19901599/23359902/95005b12-fcf9-11e6-95cd-0956fa1d5e88.png">

Then on canceling a sweet alert pops up asking you if you want to cancel the order

<img width="782" alt="screen shot 2017-02-27 at 2 17 26 pm" src="https://cloud.githubusercontent.com/assets/19901599/23359916/a0cfa600-fcf9-11e6-8c7d-30745ec6bd6c.png">

Then the order status changes to canceled after canceling

<img width="1352" alt="screen shot 2017-02-27 at 2 17 39 pm" src="https://cloud.githubusercontent.com/assets/19901599/23359922/a628f2dc-fcf9-11e6-9aa4-f27309fdb351.png">