### PR TITLE
#139284017 Add Sort and Filter to search results

### DIFF
--- a/imports/plugins/included/search-mongo/server/publications/searchresults.js
+++ b/imports/plugins/included/search-mongo/server/publications/searchresults.js
@@ -81,7 +81,9 @@ getResults.products = function (searchTerm, facets, maxResults, userId) {
         hashtags: 1,
         description: 1,
         handle: 1,
-        price: 1
+        price: 1,
+        shopId: 1,
+        vendor: 1
       },
       sort: {score: {$meta: "textScore"}},
       limit: maxResults

--- a/imports/plugins/included/ui-search/client/index.js
+++ b/imports/plugins/included/ui-search/client/index.js
@@ -14,6 +14,10 @@ import "./templates/productSearch/productItem.js";
 import "./templates/productSearch/content.html";
 import "./templates/productSearch/content.js";
 
+// Filter Product Search results
+import "./templates/searchModal/searchFilter.html";
+import "./templates/searchModal/searchFilter";
+
 // Order Search
 import "./templates/orderSearch/orderResults.html";
 import "./templates/orderSearch/orderResults.js";

--- a/imports/plugins/included/ui-search/client/templates/productSearch/productSearchTags.html
+++ b/imports/plugins/included/ui-search/client/templates/productSearch/productSearchTags.html
@@ -3,6 +3,7 @@
 
   {{#if tagSearchResults}}
   <div class="rui search-modal-tags-container">
+    {{> sortRelevance}}
     <p class="rui suggested-tags" data-i18n="search.suggestedTags">Suggested tags</p>
     <div class="rui search-tags">
       {{#each tag in tagSearchResults}}

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
@@ -42,6 +42,7 @@
         <select id="sort-value">
               <option value="ASC"><strong>Lowest price</strong></option>
               <option value="DESC"><strong>Highest price</strong></option>
+              <option value="null"><strong>Relevance</strong></option>
       </select>
   </div>
 </template>

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
@@ -1,0 +1,48 @@
+<template name="searchFilter">
+  <div id="searchFilter">
+    <div class="container customContainer">
+      <div class="row">
+
+        <div class="col-md-6">
+          <label class="transform">Price</label>
+          <div class="rui select">
+            <select id="price-filter">
+              <option value="null" selected disabled>Filter by price</option>
+              <option value="all">All prices</option>
+              <option value="0-10">below - $10</option>
+              <option value="10-55">$10 - $55</option>
+              <option value="55-100">$55 - $100</option>
+              <option value="100-500">$100 - $500</option>
+              <option value="500-1000">$500 - $1000</option>
+              <option value="1000-above">$1000 - above</option>
+            </select>
+          </div>
+        </div>
+
+        <div class="col-md-6">
+          <label class="transform">Vendor</label>
+          <div class="rui select">
+            <select id="brand-filter">
+              <option value="null" selected disabled>Filter by vendor</option>
+              <option value="all">All vendors</option>
+               {{#each brand in getBrands productSearchResults }}
+              <option value="{{brand}}">{{brand}}</option>
+              {{/each}}
+            </select>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<template name="sortRelevance">
+  <div class="sorts" id="sortRelevance">
+        <strong>Sort by:&nbsp;</strong>
+        <select id="sort-value">
+              <option value="null"><strong>Relevance</strong></option>
+              <option value="ASC"><strong>Lowest price</strong></option>
+              <option value="DESC"><strong>Highest price</strong></option>
+      </select>
+  </div>
+</template>

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.html
@@ -40,7 +40,6 @@
   <div class="sorts" id="sortRelevance">
         <strong>Sort by:&nbsp;</strong>
         <select id="sort-value">
-              <option value="null"><strong>Relevance</strong></option>
               <option value="ASC"><strong>Lowest price</strong></option>
               <option value="DESC"><strong>Highest price</strong></option>
       </select>

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.js
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchFilter.js
@@ -1,0 +1,24 @@
+import { Session } from "meteor/session";
+import { Template } from "meteor/templating";
+import _ from "underscore";
+
+Template.searchFilter.helpers({
+  getBrands(products) {
+    return _.uniq(_.pluck(products, "vendor"));
+  }
+});
+
+Template.searchFilter.events({
+  "change #price-filter": function (event) {
+    Session.set("priceFilter", event.target.value);
+  },
+  "change #brand-filter": function (event) {
+    Session.set("brandFilter", event.target.value);
+  }
+});
+
+Template.sortRelevance.events({
+  "change #sort-value": function (event) {
+    Session.set("sortValue", event.target.value);
+  }
+});

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchModal.html
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchModal.html
@@ -8,6 +8,8 @@
 
       {{> searchInput }}
 
+      {{> searchFilter productSearchResults=productSearchResults}}
+
       {{> searchTypeToggle }}
 
       {{> productSearchTags tagSearchResults=tagSearchResults }}

--- a/imports/plugins/included/ui-search/client/templates/searchModal/searchModal.js
+++ b/imports/plugins/included/ui-search/client/templates/searchModal/searchModal.js
@@ -3,6 +3,7 @@ import React from "react";
 import { DataType } from "react-taco-table";
 import { Template } from "meteor/templating";
 import { i18next } from "/client/api";
+import { Session } from "meteor/session";
 import { ProductSearch, Tags, OrderSearch, AccountSearch } from "/lib/collections";
 import { IconButton, SortableTable } from "/imports/plugins/core/ui/client/components";
 
@@ -43,10 +44,56 @@ Template.searchModal.onCreated(function () {
     }
   });
 
+  // Filter products by price
+const priceFilter = (products, query) =>  {
+  return _.filter(products, (product) => {
+    if (product.price) {
+      const productMaxPrice = parseFloat(product.price.max);
+      const productMinPrice = parseFloat(product.price.min);
+      const queryMaxPrice = parseFloat(query[1]);
+      const queryMinPrice = parseFloat(query[0]);
+      if (productMinPrice >= queryMinPrice && productMaxPrice <= queryMaxPrice) {
+        return product;
+      }
+      return false;
+    }
+  });
+};
+// Sort products by price
+const sort = (products, type) => {
+  return products.sort((a, b) => {
+    const A = a.price === null ? -1 : a.price.min;
+    const B = b.price === null ? -1 : b.price.min;
+    if (A < B) {
+      return type === "DESC" ? 1 : -1;
+    } else if (A > B) {
+      return type === "ASC" ? 1 : -1;
+    }
+    return 0;
+  });
+};
+
+
+// Filter products by brand
+function brandFilter(products, query) {
+  return _.filter(products, (product) => {
+    return product.vendor === query;
+  });
+}
+
+// Filter products by shop
+function shopFilter(products, query) {
+  return _.filter(products, (product) => {
+    return product.shopId === query;
+  });
+}
 
   this.autorun(() => {
     const searchCollection = this.state.get("searchCollection") || "products";
     const searchQuery = this.state.get("searchQuery");
+    const priceQuery = Session.get("priceFilter");
+    const brandQuery = Session.get("brandFilter");
+    const sortQuery = Session.get("sortValue");
     const facets = this.state.get("facets") || [];
     const sub = this.subscribe("SearchResults", searchCollection, searchQuery, facets);
 
@@ -55,7 +102,17 @@ Template.searchModal.onCreated(function () {
        * Product Search
        */
       if (searchCollection === "products") {
-        const productResults = ProductSearch.find().fetch();
+        let productResults = ProductSearch.find().fetch();
+        if (!["null", "all"].includes(priceQuery) && priceQuery) {
+          const range = priceQuery.split("-");
+          productResults =  priceFilter(productResults, range);
+        }
+        if (!["null", "all"].includes(brandQuery) && brandQuery) {
+          productResults = brandFilter(productResults, brandQuery);
+        }
+        if (sortQuery !== "null" && sortQuery) {
+          productResults = sort(productResults, sortQuery);
+        }
         const productResultsCount = productResults.length;
         this.state.set("productSearchResults", productResults);
         this.state.set("productSearchCount", productResultsCount);


### PR DESCRIPTION
 #### What does this PR do?
Adds sort ad filter of search results
 #### Description of Task to be completeA user should be able to further sort and filter search results on basis of price, vendor and relevance
 #### How should this be manually tested?
hit the search button and search for something the sort and filter interface will appear
 #### Any background context you want to provide?
None
 #### What are the relevant pivotal tracker stories?
#139284017
 #### Screenshots (if appropriate)
<img width="1664" alt="screen shot 2017-03-20 at 11 55 52" src="https://cloud.githubusercontent.com/assets/24463773/24093343/6e2cfe48-0d64-11e7-9b20-43a0a0a875d7.png">
<img width="1654" alt="screen shot 2017-03-20 at 11 56 08" src="https://cloud.githubusercontent.com/assets/24463773/24093344/6e2d9d3a-0d64-11e7-9a62-37bf57febdfa.png">
<img width="1664" alt="screen shot 2017-03-20 at 11 56 26" src="https://cloud.githubusercontent.com/assets/24463773/24093345/6e2dca3a-0d64-11e7-96a6-1174f7bdccf1.png">

 #### Questions:
None currently