### PR TITLE
#142927665 Trigger notifications when an order is canceled

### DIFF
--- a/server/api/graphql/graphqlServer.js
+++ b/server/api/graphql/graphqlServer.js
@@ -9,7 +9,7 @@ import { Meteor } from "meteor/meteor";
 import bcrypt from "bcrypt";
 import SHA256 from "js-sha256";
 
-const secret = process.env.SECRET || "wearethepirateswhodontdoanything";
+const secret = process.env.SECRET;
 
 const app = express();
 const PORT = 9090;

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -229,6 +229,24 @@ Meteor.methods({
    */
   "orders/cancelOrder"(order) {
     check(order, Object);
+
+    this.unblock();
+
+    const notifications = {
+      userId: order.userId,
+      name: "Order Canceled",
+      type: "canceled",
+      message: "❌ Your order has been cancelled!",
+      read: false,
+      orderId: order._id
+    };
+
+    console.log(order, notifications, notifications.type);
+
+    check(notifications, Schemas.Notifications);
+    Notifications.insert(notifications);
+
+
     // Update Order
     return Orders.update(order._id, {
       $set: {

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -241,8 +241,6 @@ Meteor.methods({
       orderId: order._id
     };
 
-    console.log(order, notifications, notifications.type);
-
     check(notifications, Schemas.Notifications);
     Notifications.insert(notifications);
 


### PR DESCRIPTION
 #### What does this PR do?
Triggers a notification when an order is canceled

 #### How should this be manually tested?
Cancel an order on the deployment either as an admin or customer and view notifications on the dashboard

 #### What are the relevant pivotal tracker stories?
#142927665

 #### Screenshots (if appropriate)
<img width="1280" alt="screen shot 2017-04-03 at 10 44 54" src="https://cloud.githubusercontent.com/assets/16131515/24599988/5bc0bfea-185b-11e7-9d3b-f6070b912ee8.png">

